### PR TITLE
Add leave-one-out modes

### DIFF
--- a/st3/__init__.py
+++ b/st3/__init__.py
@@ -1,3 +1,3 @@
 from .model import SourceTracker
 
-__all__ = ["SourceTracker"]
+__all__ = ["SourceTracker", "SourceTrackerLOO"]

--- a/st3/_results.py
+++ b/st3/_results.py
@@ -2,26 +2,23 @@ import pandas as pd
 
 
 class STResults:
-    def __init__(self, results: list, sources: list, sinks: list):
+    def __init__(self, results: dict, sources: list):
         """Container for results from SourceTracker."""
         self.results = results
         self.sources = sources + ["Unknown"]
-        self.sinks = sinks
+        self.sinks = list(results.keys())
 
-    def __getitem__(self, index: int):
-        return self.results[index]
+    def __getitem__(self, sink_id: str):
+        return self.results[sink_id]
 
     def __len__(self):
         return len(self.results)
 
-    def __iter__(self):
-        return iter(self.results)
-
     def to_dataframe(self) -> pd.DataFrame:
         """Get estimated mixing proportions as Pandas DataFrame."""
         results = [
-            x.variational_params_pd.filter(like="mix_prop")
-            for x in self.results
+            r.variational_params_pd.filter(like="mix_prop")
+            for sink, r in self.results.items()
         ]
         results = pd.concat(results)
         results.columns = self.sources
@@ -30,16 +27,16 @@ class STResults:
 
 
 class STResultsLOOCollapsed(STResults):
-    def __init__(self, results: list, sources: list):
+    def __init__(self, results: dict):
         """Container for results from SourceTrackerLOOCollapsed."""
         self.results = results
-        self.sources = sources
+        self.sources = list(results.keys())
 
     def to_dataframe(self) -> pd.DataFrame:
         """Get estimated mixing proportions as Pandas DataFrame."""
         results = []
         # For each result, get remaining sources by subsetting source list
-        for i, (src, res) in enumerate(zip(self. sources, self.results)):
+        for i, (src, res) in enumerate(self.results.items()):
             mix_props = res.variational_params_pd.filter(like="mix_prop")
             _sources = self.sources[:i] + self.sources[i+1:] + ["Unknown"]
             mix_props.columns = _sources

--- a/st3/_results.py
+++ b/st3/_results.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+
+class STResults:
+    def __init__(self, results: list, sources: list, sinks: list):
+        """Container for results from SourceTracker."""
+        self.results = results
+        self.sources = sources + ["Unknown"]
+        self.sinks = sinks
+
+    def __getitem__(self, index: int):
+        return self.results[index]
+
+    def __len__(self):
+        return len(self.results)
+
+    def __iter__(self):
+        return iter(self.results)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Get estimated mixing proportions as Pandas DataFrame."""
+        results = [
+            x.variational_params_pd.filter(like="mix_prop")
+            for x in self.results
+        ]
+        results = pd.concat(results)
+        results.columns = self.sources
+        results.index = self.sinks
+        return results
+
+
+class STResultsLOOCollapsed(STResults):
+    def __init__(self, results: list, sources: list):
+        """Container for results from SourceTrackerLOOCollapsed."""
+        self.results = results
+        self.sources = sources
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Get estimated mixing proportions as Pandas DataFrame."""
+        results = []
+        # For each result, get remaining sources by subsetting source list
+        for i, (src, res) in enumerate(zip(self. sources, self.results)):
+            mix_props = res.variational_params_pd.filter(like="mix_prop")
+            _sources = self.sources[:i] + self.sources[i+1:] + ["Unknown"]
+            mix_props.columns = _sources
+            results.append(mix_props)
+
+        results = pd.concat(results)[self.sources + ["Unknown"]]
+        results.index = self.sources
+        return results

--- a/st3/model.py
+++ b/st3/model.py
@@ -164,8 +164,9 @@ class SourceTracker(STBase):
         results = Parallel(n_jobs=jobs, **parallel_args)(
             delayed(func)(vals) for vals in sink_data.iter_data()
         )
+        results = dict(zip(sinks.ids(), results))
 
-        results = STResults(results, self.sources, sinks.ids())
+        results = STResults(results, self.sources)
         return results
 
 
@@ -262,8 +263,9 @@ class SourceTrackerLOO(STBase):
         results = Parallel(n_jobs=jobs, **parallel_args)(
             delayed(func)(samp_name) for samp_name in self.samples
         )
+        results = dict(zip(self.samples, results))
 
-        results = STResults(results, self.sources, self.samples)
+        results = STResults(results, self.sources)
         return results
 
     def _fit_single(
@@ -403,7 +405,9 @@ class SourceTrackerLOOCollapsed(STBase):
         results = Parallel(n_jobs=jobs, **parallel_args)(
             delayed(func)(source) for source in self.sources
         )
-        results = STResultsLOOCollapsed(results, self.sources)
+        results = dict(zip(self.sources, results))
+
+        results = STResultsLOOCollapsed(results)
         return results
 
     def _fit_single(

--- a/st3/model.py
+++ b/st3/model.py
@@ -271,7 +271,7 @@ class SourceTrackerLOO(STBase):
         sample_name: str,
         temp_dir: pathlib.Path,
         **kwargs
-    ):
+    ) -> CmdStanVB:
         """Fit a single hold-out sample.
 
         :param sample_name: Name of training sample to use as hold-out
@@ -412,6 +412,20 @@ class SourceTrackerLOOCollapsed(STBase):
         temp_dir: pathlib.Path,
         **kwargs
     ) -> CmdStanVB:
+        """Fit a single sink sample.
+
+        :param left_out_source: Source to hold-out during model fitting
+        :type left_out_source: str
+
+        :param temp_dir: Temporary directory in which to save intermediate
+            CSVs creating during sampling
+        :type temp_dir: pathlib.Path
+
+        :param **kwargs: Keyword arguments to pass to CmdStanModel.variational
+
+        :returns: Model fitted through variational inference
+        :rtype: cmdstanpy.CmdStanVB
+        """
         source_data, sink_data = self._leave_source_out(left_out_source)
         results = super()._fit_single(
             sink_data, source_data, temp_dir=temp_dir, **kwargs

--- a/st3/tests/test_model.py
+++ b/st3/tests/test_model.py
@@ -19,8 +19,15 @@ def st3_model_results(st3_model):
     return model.fit(sink_tbl)
 
 
+def test_results(st3_model, st3_model_results):
+    sink_tbl, _ = st3_model
+    assert list(st3_model_results.results.keys()) == list(sink_tbl.ids())
+
+
 def test_results_type(st3_model_results):
-    assert all([isinstance(r, CmdStanVB) for r in st3_model_results])
+    assert all([
+        isinstance(r, CmdStanVB) for _, r in st3_model_results.results.items()
+    ])
 
 
 def test_results_to_df(st3_model, st3_model_results):

--- a/st3/tests/test_model_loo.py
+++ b/st3/tests/test_model_loo.py
@@ -1,6 +1,6 @@
 import pytest
 
-from st3.model import SourceTrackerLOO
+from st3.model import SourceTrackerLOO, SourceTrackerLOOCollapsed
 
 
 @pytest.fixture
@@ -15,8 +15,12 @@ def example_data_loo(example_data):
 def test_st3_loo(example_data_loo):
     table, metadata = example_data_loo
     st3_loo = SourceTrackerLOO(table, metadata)
-    # source, sink = st3_loo._get_source_sink("SRC_1_SAMP_1")
     results = st3_loo.fit()
     results_df = results.to_dataframe()
-    print(results_df)
-    assert 0
+
+
+def test_st3_loo_collapsed(example_data_loo):
+    table, metadata = example_data_loo
+    st3_loo_coll = SourceTrackerLOOCollapsed(table, metadata)
+    results = st3_loo_coll.fit()
+    results_df = results.to_dataframe()

--- a/st3/tests/test_model_loo.py
+++ b/st3/tests/test_model_loo.py
@@ -1,0 +1,22 @@
+import pytest
+
+from st3.model import SourceTrackerLOO
+
+
+@pytest.fixture
+def example_data_loo(example_data):
+    table, metadata = example_data
+    samps_to_keep = metadata[metadata["SourceSink"] == "source"].index
+    table = table.filter(samps_to_keep, inplace=False)
+    metadata = metadata.loc[list(table.ids())]
+    return table, metadata
+
+
+def test_st3_loo(example_data_loo):
+    table, metadata = example_data_loo
+    st3_loo = SourceTrackerLOO(table, metadata)
+    # source, sink = st3_loo._get_source_sink("SRC_1_SAMP_1")
+    results = st3_loo.fit()
+    results_df = results.to_dataframe()
+    print(results_df)
+    assert 0

--- a/st3/tests/test_model_loo.py
+++ b/st3/tests/test_model_loo.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 from st3.model import SourceTrackerLOO, SourceTrackerLOOCollapsed
@@ -35,3 +37,7 @@ def test_st3_loo_collapsed(example_data_loo):
 
     exp_sources = [f"SRC_{x+1}" for x in range(5)]
     assert list(results_df.index) == exp_sources
+
+    for src, row in results_df.iterrows():
+        assert pd.isna(row[src])
+        np.testing.assert_almost_equal(row.sum(), 1, decimal=4)

--- a/st3/tests/test_model_loo.py
+++ b/st3/tests/test_model_loo.py
@@ -18,9 +18,20 @@ def test_st3_loo(example_data_loo):
     results = st3_loo.fit()
     results_df = results.to_dataframe()
 
+    exp_cols = [f"SRC_{x+1}" for x in range(5)] + ["Unknown"]
+    assert list(results_df.columns) == exp_cols
+
+    assert (metadata.index == results_df.index).all()
+
 
 def test_st3_loo_collapsed(example_data_loo):
     table, metadata = example_data_loo
     st3_loo_coll = SourceTrackerLOOCollapsed(table, metadata)
     results = st3_loo_coll.fit()
     results_df = results.to_dataframe()
+
+    exp_cols = [f"SRC_{x+1}" for x in range(5)] + ["Unknown"]
+    assert list(results_df.columns) == exp_cols
+
+    exp_sources = [f"SRC_{x+1}" for x in range(5)]
+    assert list(results_df.index) == exp_sources


### PR DESCRIPTION
Adds two modes of operation:

1) Leave-one-sample out: each sample is left out and treated as a sink sample
2) Leave-one-source out: each *source* is left out and treated as a sink sample